### PR TITLE
Travis: move the build to travis' new infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-language: erlang
+language: c
+sudo: required
+dist: trusty
 
 env:
   - LUA="lua5.1" LUAC="luac5.1"
@@ -8,7 +10,8 @@ branches:
     - master
 
 install:
-  - sudo apt-get install $LUA luarocks
+  - sudo apt-get update -qq
+  - sudo apt-get install -y $LUA luarocks
   - sudo luarocks install luaunit
   - sudo luarocks install mockagne
   - sudo luarocks install luabitop


### PR DESCRIPTION
Travis switched to Google Compute Engine in December, which caused some problems:

- the Erlang language does not seem to install properly on their VMs, this is not a problem for us, I switched it to C to avoid the error messages
- `sudo: required` is actually not required since the repos here are known to Travis since before 1.1.2015 and thus will not be ran on their container infrastructure where sudo is not allowed. I added this as future-proof in case they change this behavior.
- `dist: trusty` will move the build from Ubuntu 12 (Precise) to Ubuntu 14 (Trusty). Precise comes with Git 1.8.5, which has a problem with the rockspec of LuaBitOp, which has a non-existent branch name in it (they used `branch` instead of `tag` I think). Trusty has Git 1.9.1 and sorts this out warning about a detached head state of the LuaBitOp repo. The whole situation with LuaBitOp seems strange as there are 2 different github accounts (LuaDist and LuaDist2) that govern it. The version on luarocks.org is from LuaDist, but they say it got updated to 1.0.2-3 some 50 days ago, where the git repo is not updated since 2013. The LuaDist2 repo seems to be the right one, but I can't know for sure.
- `apt-get update` is required as it does not find the packages to install without it
- The `-y` switch is needed for unattended installs